### PR TITLE
Fixing bug with responsive design

### DIFF
--- a/main.css
+++ b/main.css
@@ -430,7 +430,6 @@ h4{
 
 #social{
     width: 700px;
-    height: 35vh;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
@@ -655,6 +654,11 @@ textarea:focus::placeholder, #social form input:focus::placeholder{
     }
     #pfpfigure{
         scale: 0.8;
+    }
+}
+@media only screen and (max-width: 768px) {
+    #geologist{
+        display: none;
     }
 }
 @media only screen and (min-width: 425px){


### PR DESCRIPTION
Simple fix with @media and removing the fixed height of the #social div at the end of the page. Now, the geologist is gone on screens of width lower than 768px, and the #social can adjust its height based on the flex-flow, thus removing bugs that were happening in the sticky layer sections in front.